### PR TITLE
qunit chokes on rejected promises with undefined value

### DIFF
--- a/can-define-connected-singleton-test.js
+++ b/can-define-connected-singleton-test.js
@@ -166,7 +166,7 @@ QUnit.test('Destroying sets the "current" property to undefined, with rejected p
 				QUnit.notOk(true, 'should not get here');
 				done();
 			}).catch(function(value) {
-				QUnit.equal(value, undefined);
+				QUnit.propEqual(value, {});
 				done();
 			});
 		});
@@ -201,7 +201,7 @@ QUnit.test('Allows for configurable destroy method name', function(assert){
 				QUnit.notOk(true, 'should not get here');
 				done();
 			}).catch(function(value) {
-				QUnit.equal(value, undefined);
+				QUnit.propEqual(value, {});
 				done();
 			});
 		});
@@ -229,7 +229,7 @@ QUnit.test('Setting .current manually results in expected state.', function(asse
 
 	MyType.current = undefined;
 	assert.equal(MyType.current, undefined);
-	promises.push(MyType.currentPromise.catch((msg) => assert.equal(msg, undefined)));
+	promises.push(MyType.currentPromise.catch((msg) => assert.propEqual(msg, {})));
 
 	Promise.all(promises).then(() => done());
 });

--- a/can-define-connected-singleton.js
+++ b/can-define-connected-singleton.js
@@ -60,7 +60,7 @@ function wrapDestroyMethod(Ctor, options) {
 		var ret = baseDestroy.apply(this, arguments);
 
 		ret.then(() => {
-			var promise = Promise.reject(undefined);
+			var promise = Promise.reject({});
 
 			// clear current, reject currentPromise w/ reason string if successful
 			zoneStorage.setItem(options.storageKeys.currentProperty, undefined);
@@ -153,7 +153,7 @@ function makeSingleton(Ctor, input_options){
 
 			let promise = instance ?
 				Promise.resolve(instance) :
-				Promise.reject(undefined);
+				Promise.reject({});
 
 			zoneStorage.setItem(options.storageKeys.currentProperty, instance);
 			Ctor.dispatch(options.currentPropertyName, [instance]);


### PR DESCRIPTION
When trying to handle unhandled rejections QUnit errors while looking for `rejectedVal.message` if rejectedVal is undefined.